### PR TITLE
fix crash in accessing released block, sorting elements and warnings

### DIFF
--- a/MagicPieLayer/PieLayer.h
+++ b/MagicPieLayer/PieLayer.h
@@ -47,7 +47,7 @@ typedef enum ShowTitles
 @property (nonatomic, assign) float animationDuration;//default 0.6
 @property (nonatomic, assign) ShowTitle showTitles;//defaul ShowTitleNever
 
-@property (nonatomic, assign) NSString*(^transformTitleBlock)(PieElement* val);
+@property (nonatomic, copy) NSString*(^transformTitleBlock)(PieElement* val);
 
 - (void)setMaxRadius:(float)maxRadius minRadius:(float)minRadius animated:(BOOL)isAnimated;
 - (void)setStartAngle:(float)startAngle endAngle:(float)endAngle animated:(BOOL)isAnimated;

--- a/MagicPieLayer/PieLayer.m
+++ b/MagicPieLayer/PieLayer.m
@@ -151,7 +151,7 @@ static NSString * const _animationValuesKey = @"animationValues";
     NSMutableArray* sortedArray = [array mutableCopy];
     [sortedArray sortWithIndexes:indexes];
     NSMutableArray* sortedIndexes = [indexes mutableCopy];
-    [sortedArray sortUsingSelector:@selector(compare:)];
+    [sortedIndexes sortUsingSelector:@selector(compare:)];
     
     NSMutableArray* newValues = [NSMutableArray arrayWithArray:self.values];
     [newValues insertSortedObjects:sortedArray indexes:indexes];
@@ -516,8 +516,11 @@ static NSString * const _animationValuesKey = @"animationValues";
     while (angle >= 2*M_PI - M_PI_4) {
         angle -= M_PI*2;
     }
-    
+#if (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0)
     CGSize textSize = [text sizeWithFont:self.font];
+#else
+    CGSize textSize = [text sizeWithAttributes:@{NSFontAttributeName:self.font}];
+#endif
     CGPoint anchorPoint;
     //clockwise
     if(angle >= -M_PI_4 && angle < M_PI_4){
@@ -538,7 +541,12 @@ static NSString * const _animationValuesKey = @"animationValues";
                               textSize.width,
                               textSize.height);
     UIGraphicsPushContext(ctx);
+#if (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0)
     [text drawInRect:frame withFont:self.font];
+#else
+    [text drawInRect:frame withAttributes:@{NSFontAttributeName:self.font}];
+#endif
+    
     UIGraphicsPopContext();
 }
 


### PR DESCRIPTION
copy block property to allow use of stack blocks
fix deprecated warnings on iOS7
fix sorting with more then 1 index
