### PR TITLE
Added indexing ability to pie elements

### DIFF
--- a/MagicPie.xcodeproj/project.pbxproj
+++ b/MagicPie.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		877D1D35193D99DC0040AB4A /* Example4PieView.m in Sources */ = {isa = PBXBuildFile; fileRef = 877D1D2F193D99DC0040AB4A /* Example4PieView.m */; };
+		877D1D36193D99DC0040AB4A /* MyPieElemntExample4.m in Sources */ = {isa = PBXBuildFile; fileRef = 877D1D31193D99DC0040AB4A /* MyPieElemntExample4.m */; };
+		877D1D37193D99DC0040AB4A /* Example4Controller.m in Sources */ = {isa = PBXBuildFile; fileRef = 877D1D33193D99DC0040AB4A /* Example4Controller.m */; };
+		877D1D38193D99DC0040AB4A /* Example4Controller.xib in Resources */ = {isa = PBXBuildFile; fileRef = 877D1D34193D99DC0040AB4A /* Example4Controller.xib */; };
 		A8AFA913186B6138001AEF6A /* NSArray+descValues.m in Sources */ = {isa = PBXBuildFile; fileRef = A8AFA912186B6138001AEF6A /* NSArray+descValues.m */; };
 		A8AFA95E186DFF70001AEF6A /* NSMutableArray+pieEx.m in Sources */ = {isa = PBXBuildFile; fileRef = A8AFA95D186DFF70001AEF6A /* NSMutableArray+pieEx.m */; };
 		A8AFA9631871FEB4001AEF6A /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A8AFA9611871FEB4001AEF6A /* ViewController.m */; };
@@ -52,6 +56,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		877D1D2E193D99C80040AB4A /* Example4PieView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Example4PieView.h; sourceTree = "<group>"; };
+		877D1D2F193D99DC0040AB4A /* Example4PieView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Example4PieView.m; sourceTree = "<group>"; };
+		877D1D30193D99DC0040AB4A /* MyPieElemntExample4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MyPieElemntExample4.h; sourceTree = "<group>"; };
+		877D1D31193D99DC0040AB4A /* MyPieElemntExample4.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MyPieElemntExample4.m; sourceTree = "<group>"; };
+		877D1D32193D99DC0040AB4A /* Example4Controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Example4Controller.h; sourceTree = "<group>"; };
+		877D1D33193D99DC0040AB4A /* Example4Controller.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Example4Controller.m; sourceTree = "<group>"; };
+		877D1D34193D99DC0040AB4A /* Example4Controller.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = Example4Controller.xib; sourceTree = "<group>"; };
 		A8AFA911186B6138001AEF6A /* NSArray+descValues.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+descValues.h"; sourceTree = "<group>"; };
 		A8AFA912186B6138001AEF6A /* NSArray+descValues.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+descValues.m"; sourceTree = "<group>"; };
 		A8AFA95C186DFF70001AEF6A /* NSMutableArray+pieEx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableArray+pieEx.h"; sourceTree = "<group>"; };
@@ -130,6 +141,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		877D1D2D193D996D0040AB4A /* Example4 */ = {
+			isa = PBXGroup;
+			children = (
+				877D1D2F193D99DC0040AB4A /* Example4PieView.m */,
+				877D1D30193D99DC0040AB4A /* MyPieElemntExample4.h */,
+				877D1D31193D99DC0040AB4A /* MyPieElemntExample4.m */,
+				877D1D32193D99DC0040AB4A /* Example4Controller.h */,
+				877D1D33193D99DC0040AB4A /* Example4Controller.m */,
+				877D1D34193D99DC0040AB4A /* Example4Controller.xib */,
+				877D1D2E193D99C80040AB4A /* Example4PieView.h */,
+			);
+			name = Example4;
+			sourceTree = "<group>";
+		};
 		A8AFA914186B6202001AEF6A /* Help */ = {
 			isa = PBXGroup;
 			children = (
@@ -245,6 +270,7 @@
 		BD0CFE5D17F94CC60038FBC1 /* MagicPie */ = {
 			isa = PBXGroup;
 			children = (
+				877D1D2D193D996D0040AB4A /* Example4 */,
 				BD092F5F1807E1B500E1C0E6 /* MagicPieLayer */,
 				A8AFA95F1871FD94001AEF6A /* Example1 */,
 				A8AFA9651872058C001AEF6A /* Example2 */,
@@ -374,6 +400,7 @@
 				A8C814C2188B0BDD00D71B88 /* sample.m4a in Resources */,
 				A8C814BA188B00F300D71B88 /* Example3Controller.xib in Resources */,
 				BD0CFE7017F94CC60038FBC1 /* Images.xcassets in Resources */,
+				877D1D38193D99DC0040AB4A /* Example4Controller.xib in Resources */,
 				BDD303C618052C5A00380FBA /* Example1Controller.xib in Resources */,
 				A8AFA9641871FEB4001AEF6A /* ViewController.xib in Resources */,
 				BD0CFE6217F94CC60038FBC1 /* InfoPlist.strings in Resources */,
@@ -403,6 +430,8 @@
 				A8AFA96F1872081D001AEF6A /* Example2Controller.m in Sources */,
 				BD0CFE6E17F94CC60038FBC1 /* Example1Controller.m in Sources */,
 				A8C814C5188B0C8700D71B88 /* Example3PieView.m in Sources */,
+				877D1D35193D99DC0040AB4A /* Example4PieView.m in Sources */,
+				877D1D36193D99DC0040AB4A /* MyPieElemntExample4.m in Sources */,
 				A8AFA9631871FEB4001AEF6A /* ViewController.m in Sources */,
 				BD0CFE6817F94CC60038FBC1 /* AppDelegate.m in Sources */,
 				BD0CFEEC17FE98150038FBC1 /* TestPieLayer.m in Sources */,
@@ -413,6 +442,7 @@
 				A8AFA968187205AA001AEF6A /* Example2PieView.m in Sources */,
 				A8BB7718188B9D2E00A90439 /* Example3PieLayer.m in Sources */,
 				BD0CFE6417F94CC60038FBC1 /* main.m in Sources */,
+				877D1D37193D99DC0040AB4A /* Example4Controller.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MagicPie/Example4Controller.h
+++ b/MagicPie/Example4Controller.h
@@ -1,0 +1,13 @@
+//
+//  Example4Controller.h
+//  MagicPie
+//
+//  Created by Madusha Perera on 6/2/14.
+//  Copyright (c) 2014 Alexandr Corporation. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface Example4Controller : UIViewController
+
+@end

--- a/MagicPie/Example4Controller.m
+++ b/MagicPie/Example4Controller.m
@@ -1,0 +1,64 @@
+//
+//  Example2Controller.m
+//  MagicPie
+//
+//  Created by Alexander on 30.12.13.
+//  Copyright (c) 2013 Alexandr Corporation. All rights reserved.
+//
+
+#import "Example4Controller.h"
+#import "Example4PieView.h"
+#import "MyPieElemntExample4.h"
+#import "PieLayer.h"
+
+@interface Example4Controller ()
+{
+    BOOL showPercent;
+}
+@property (nonatomic, weak) IBOutlet Example4PieView* pieView;
+@property (weak, nonatomic) IBOutlet UILabel *indexPressed;
+
+@end
+
+@implementation Example4Controller
+@synthesize pieView;
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    
+    // the values to be drawn in pie chart
+    float vals[] = {505.0,505.0,0.0,70.0,0.0};
+    
+    for(int i = 0 ;  i<5 ; i++ ){
+        float val = vals[i];
+        MyPieElemntExample4* elem = [MyPieElemntExample4 pieElementWithValue:val indexValue:(NSInteger*)i color:[self randomColor]];
+        elem.title = [NSString stringWithFormat:@"index %d", i];
+        [pieView.layer addValues:@[elem] animated:NO];
+    }
+    
+    //much easier do this with array outside
+    showPercent = NO;
+    pieView.layer.transformTitleBlock = ^(PieElement* elem, float percent){
+        return [(MyPieElemntExample4*)elem title];
+    };
+    pieView.layer.showTitles = ShowTitlesAlways;
+}
+
+- (UIColor*)randomColor
+{
+    CGFloat hue = ( arc4random() % 256 / 256.0 );  //  0.0 to 1.0
+    CGFloat saturation = ( arc4random() % 128 / 256.0 ) + 0.5;  //  0.5 to 1.0, away from white
+    CGFloat brightness = ( arc4random() % 128 / 256.0 ) + 0.5;  //  0.5 to 1.0, away from black
+    return [UIColor colorWithHue:hue saturation:saturation brightness:brightness alpha:1];
+}
+
+
+- (IBAction)backPressed:(id)sender
+{
+    [self dismissModalViewControllerAnimated:YES];
+}
+
+
+
+@end

--- a/MagicPie/Example4Controller.xib
+++ b/MagicPie/Example4Controller.xib
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4510" systemVersion="12F45" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+    <dependencies>
+        <deployment defaultVersion="1280" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3742"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="Example4Controller">
+            <connections>
+                <outlet property="pieView" destination="1" id="yJb-1L-dzL"/>
+                <outlet property="view" destination="1" id="3"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1" customClass="Example4PieView">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="tYq-hW-gqU">
+                    <rect key="frame" x="14" y="20" width="58" height="30"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="&lt;= Back">
+                        <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="backPressed:" destination="-1" eventType="touchUpInside" id="cpy-aP-K6y"/>
+                    </connections>
+                </button>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+        </view>
+    </objects>
+</document>

--- a/MagicPie/Example4PieView.h
+++ b/MagicPie/Example4PieView.h
@@ -1,0 +1,20 @@
+//
+//  Example4PieView.h
+//  MagicPie
+//
+//  Created by Madusha Perera on 6/2/14.
+//  Copyright (c) 2014 Alexandr Corporation. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class PieLayer;
+
+@interface Example4PieView : UIView
+
+@end
+
+@interface Example4PieView (ex)
+@property(nonatomic,readonly,retain) PieLayer *layer;
+
+@end

--- a/MagicPie/Example4PieView.m
+++ b/MagicPie/Example4PieView.m
@@ -1,0 +1,91 @@
+//
+//  Example4PieView.m
+//  MagicPie
+//
+//  Created by Madusha Perera on 6/2/14.
+//  Copyright (c) 2014 Alexandr Corporation. All rights reserved.
+//
+
+#import "Example4PieView.h"
+#import "MagicPieLayer.h"
+
+@interface Example4PieView ()
+@end
+
+@implementation Example4PieView
+
++ (Class)layerClass
+{
+    return [PieLayer class];
+}
+
+- (id)init
+{
+    self = [super init];
+    if(self){
+        [self setup];
+    }
+    return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if(self){
+        [self setup];
+    }
+    return self;
+}
+
+- (id)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if(self){
+        [self setup];
+    }
+    return self;
+}
+
+- (void)setup
+{
+    self.layer.maxRadius = 100;
+    self.layer.minRadius = 20;
+    self.layer.animationDuration = 0.6;
+    self.layer.showTitles = ShowTitlesIfEnable;
+    if ([self.layer.self respondsToSelector:@selector(setContentsScale:)])
+    {
+        self.layer.contentsScale = [[UIScreen mainScreen] scale];
+    }
+    
+    
+    UITapGestureRecognizer* tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
+    tap.numberOfTapsRequired = 1;
+    tap.numberOfTouchesRequired = 1;
+    [self addGestureRecognizer:tap];
+}
+
+- (void)handleTap:(UITapGestureRecognizer*)tap
+{
+    if(tap.state != UIGestureRecognizerStateEnded)
+        return;
+    
+    CGPoint pos = [tap locationInView:tap.view];
+    PieElement* tappedElem = [self.layer pieElemInPoint:pos];
+    
+    if(!tappedElem)
+        return;
+    
+    if(tappedElem.centrOffset > 0)
+        tappedElem = nil;
+
+    NSLog(@"tapped value: %@", tappedElem );
+    NSLog(@"tapped index: %i", tappedElem.index);
+   
+    [PieElement animateChanges:^{
+        for(PieElement* elem in self.layer.values){
+            elem.centrOffset = tappedElem==elem? 20 : 0;
+        }
+    }];
+}
+
+@end

--- a/MagicPie/MyPieElemntExample4.h
+++ b/MagicPie/MyPieElemntExample4.h
@@ -1,0 +1,13 @@
+//
+//  MyPieElemnt.h
+//  MagicPie
+//
+//  Created by Madusha Perera on 6/2/14.
+//  Copyright (c) 2014 Alexandr Corporation. All rights reserved.
+//
+
+#import "PieElement.h"
+
+@interface MyPieElemntExample4 : PieElement
+@property (nonatomic, strong) NSString* title;
+@end

--- a/MagicPie/MyPieElemntExample4.m
+++ b/MagicPie/MyPieElemntExample4.m
@@ -1,0 +1,21 @@
+//
+//  MyPieElement.m
+//  MagicPie
+//
+//  Created by Alexander on 31.12.13.
+//  Copyright (c) 2013 Alexandr Corporation. All rights reserved.
+//
+
+#import "MyPieElemntExample4.h"
+
+@implementation MyPieElemntExample4
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    MyPieElemntExample4 *copyElem = [super copyWithZone:zone];
+    copyElem.title = self.title;
+    
+    return copyElem;
+}
+
+@end

--- a/MagicPie/ViewController.m
+++ b/MagicPie/ViewController.m
@@ -10,6 +10,7 @@
 #import "Example1Controller.h"
 #import "Example2Controller.h"
 #import "Example3Controller.h"
+#import "Example4Controller.h"
 
 @interface ViewController ()
 
@@ -55,5 +56,12 @@
     Example3Controller* exContr = [Example3Controller new];
     [self presentModalViewController:exContr animated:YES];
 }
+
+- (IBAction)example4Pressed:(id)sender
+{
+    Example4Controller* exContr = [Example4Controller new];
+    [self presentModalViewController:exContr animated:YES];
+}
+
 
 @end

--- a/MagicPie/ViewController.xib
+++ b/MagicPie/ViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4514" systemVersion="13B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4510" systemVersion="12F45" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
     <dependencies>
         <deployment defaultVersion="1280" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3742"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ViewController">
@@ -49,6 +49,18 @@
                     </state>
                     <connections>
                         <action selector="example3Pressed:" destination="-1" eventType="touchUpInside" id="6Zw-L7-8ws"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="1ec-Er-WbR">
+                    <rect key="frame" x="10" y="205" width="300" height="40"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" red="0.30630134320000002" green="0.61960767660000005" blue="0.55776294469999999" alpha="1" colorSpace="calibratedRGB"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                    <state key="normal" title="Example 4">
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="example4Pressed:" destination="-1" eventType="touchUpInside" id="nAX-it-83E"/>
                     </connections>
                 </button>
             </subviews>

--- a/MagicPieLayer/PieElement.h
+++ b/MagicPieLayer/PieElement.h
@@ -30,8 +30,11 @@
 
 + (instancetype)pieElementWithValue:(float)val color:(UIColor*)color;
 
++ (instancetype)pieElementWithValue:(float)val indexValue:(NSInteger*)index color:(UIColor*)color;
+
 + (void)animateChanges:(void(^)())changesBlock;
 
+@property (nonatomic, assign) NSInteger* index;
 @property (nonatomic, assign) float val;
 @property (nonatomic, strong) UIColor* color;
 @property (nonatomic, assign) float centrOffset;

--- a/MagicPieLayer/PieElement.m
+++ b/MagicPieLayer/PieElement.m
@@ -53,6 +53,15 @@ static BOOL animateChanges;
     return result;
 }
 
++ (instancetype)pieElementWithValue:(float)val indexValue:(NSInteger*)index color:(UIColor*)color
+{
+    PieElement* result = [self new];
+    result->_val = val;
+    result->_color = color;
+    result->_index = index;
+    return result;
+}
+
 - (id)copyWithZone:(NSZone *)zone
 {
     PieElement *another = [[[self class] allocWithZone:zone] init];


### PR DESCRIPTION
Recently when we were using this awesome library we found that it'll be more convenient to know what's the exact pie element that is tapped being mapped with the input array index. That is if the the input values are in an array as below, 
float vals[] = {505.0,505.0,0.0,70.0,0.0};
then when the relative pie element is tapped there's no way to identify which pie element is mapped with the index of the above array elements. It gets worse when the there are identical values in the array as above. for example which 505.0 is the user tapped in the pie chart? is it the element at 0th index or at index 1.

For that reason I have added another overload init method that will map the array index as well.
- (instancetype)pieElementWithValue:(float)val indexValue:(NSInteger_)index color:(UIColor_)color; 

Hope this may be convenient to others in their developments.
